### PR TITLE
Optimize device information retrieval error handling

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java
@@ -115,7 +115,7 @@ public class QueueingThreadPoolExecutor extends ThreadPoolExecutor {
             synchronized (this) {
                 // check again to make sure it has not been created by another thread
                 if (queueThread == null || !queueThread.isAlive()) {
-                    logger.warn("Thread pool '{}' exhausted, queueing tasks now.", threadPoolName);
+                    logger.info("Thread pool '{}' exhausted, queueing tasks now.", threadPoolName);
                     queueThread = createNewQueueThread();
                     queueThread.start();
                 }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/spi/AbstractStreamClient.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/spi/AbstractStreamClient.java
@@ -14,7 +14,11 @@
 
 package org.jupnp.transport.spi;
 
+import java.net.URI;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -28,45 +32,56 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implements the timeout/callback processing and unifies exception handling.
-
+ * 
  * @author Christian Bauer
  */
 public abstract class AbstractStreamClient<C extends StreamClientConfiguration, REQUEST> implements StreamClient<C> {
 
     private final Logger log = LoggerFactory.getLogger(StreamClient.class);
 
+    private static final int FAILED_REQUESTS_MAX_SIZE = 100;
+    private Map<URI, Long> failedRequests = new ConcurrentHashMap<URI, Long>();
+
     @Override
     public StreamResponseMessage sendRequest(StreamRequestMessage requestMessage) throws InterruptedException {
         log.trace("Preparing HTTP request: " + requestMessage);
+
+        // We want to track how long it takes
+        long start = System.nanoTime();
+
+        final Long previeousFailureTime = failedRequests.get(requestMessage.getUri());
+        if (getConfiguration().getRetryAfterSeconds() > 0 && previeousFailureTime != null) {
+            if (start - previeousFailureTime < TimeUnit.SECONDS
+                    .toNanos(getConfiguration().getRetryAfterSeconds())) {
+                log.info("Will not attempt request because it failed in the last {} seconds: {}",
+                        getConfiguration().getRetryAfterSeconds(), requestMessage);
+                return null;
+            } else {
+                failedRequests.remove(requestMessage.getUri());
+            }
+        }
 
         REQUEST request = createRequest(requestMessage);
         if (request == null)
             return null;
 
         Callable<StreamResponseMessage> callable = createCallable(requestMessage, request);
-
-        // We want to track how long it takes
-        long start = System.currentTimeMillis();
+        RequestWrapper requestWrapper = new RequestWrapper(callable);
 
         // Execute the request on a new thread
-        Future<StreamResponseMessage> future =
-            getConfiguration().getRequestExecutorService().submit(callable);
+        Future<StreamResponseMessage> future = getConfiguration().getRequestExecutorService().submit(requestWrapper);
 
         // Wait on the current thread for completion
         try {
-            log.trace(
-                "Waiting " + getConfiguration().getTimeoutSeconds()
-                + " seconds for HTTP request to complete: " + requestMessage
-            );
-            StreamResponseMessage response =
-                future.get(getConfiguration().getTimeoutSeconds(), TimeUnit.SECONDS);
+            log.trace("Waiting {} seconds for HTTP request to complete: {}", getConfiguration().getTimeoutSeconds(), requestMessage);
+            StreamResponseMessage response = future.get(getConfiguration().getTimeoutSeconds(), TimeUnit.SECONDS);
 
             // Log a warning if it took too long
-            long elapsed = System.currentTimeMillis() - start;
+            long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
             log.trace("Got HTTP response in {} ms: {}", elapsed, requestMessage);
             if (getConfiguration().getLogWarningSeconds() > 0
-                    && elapsed > getConfiguration().getLogWarningSeconds() * 1000) {
-                log.warn("HTTP request took a long time (" + elapsed + "ms): " + requestMessage);
+                    && elapsed > TimeUnit.SECONDS.toMillis(getConfiguration().getLogWarningSeconds())) {
+                log.warn("HTTP request took a long time ({} ms): {}", elapsed, requestMessage);
             }
 
             return response;
@@ -78,11 +93,11 @@ public abstract class AbstractStreamClient<C extends StreamClientConfiguration, 
 
         } catch (TimeoutException ex) {
 
-            log.info(
-                "Timeout of " + getConfiguration().getTimeoutSeconds()
-                + " seconds while waiting for HTTP request to complete, aborting: " + requestMessage
-            );
+            log.info("Timeout of {} seconds while waiting for HTTP request to complete, aborting: {}",
+                    getConfiguration().getTimeoutSeconds(), requestMessage);
             abort(request);
+
+            handleRequestTimeout(requestMessage, requestWrapper);
             return null;
 
         } catch (ExecutionException ex) {
@@ -98,6 +113,8 @@ public abstract class AbstractStreamClient<C extends StreamClientConfiguration, 
                     log.warn(message + " (" + Exceptions.unwrap(cause).getMessage() + ")");
                 }
             }
+
+            handleRequestFailure(requestMessage);
             return null;
         } finally {
             onFinally(request);
@@ -128,6 +145,65 @@ public abstract class AbstractStreamClient<C extends StreamClientConfiguration, 
 
     protected void onFinally(REQUEST request) {
         // Do nothing
+    }
+
+    private void handleRequestFailure(StreamRequestMessage requestMessage) {
+        if (getConfiguration().getRetryAfterSeconds() <= 0) {
+            return;
+        }
+
+        final long currentTime = System.nanoTime();
+        failedRequests.put(requestMessage.getUri(), currentTime);
+
+        if (failedRequests.size() > FAILED_REQUESTS_MAX_SIZE) {
+            cleanOldFailedRequests(currentTime);
+        }
+    }
+
+    private void handleRequestTimeout(StreamRequestMessage requestMessage, RequestWrapper requestWrapper) {
+        if (getConfiguration().getRetryAfterSeconds() <= 0) {
+            return;
+        }
+
+        final long currentTime = System.nanoTime();
+        if (requestWrapper.startTime != null && currentTime - requestWrapper.startTime > TimeUnit.SECONDS
+                .toNanos(getConfiguration().getTimeoutSeconds())) {
+            failedRequests.put(requestMessage.getUri(), currentTime);
+        }
+
+        cleanOldFailedRequests(currentTime);
+    }
+
+    private void cleanOldFailedRequests(long currentTime) {
+        if (failedRequests.size() <= FAILED_REQUESTS_MAX_SIZE) {
+            return;
+        }
+
+        Iterator<Map.Entry<URI, Long>> it = failedRequests.entrySet().iterator();
+        while (it.hasNext()) {
+            Long elapsedTime = currentTime - it.next().getValue();
+            if (elapsedTime > TimeUnit.SECONDS.toNanos(getConfiguration().getRetryAfterSeconds())) {
+                it.remove();
+            }
+        }
+    }
+
+    // Wrap the Callables to track if execution started or if it timed out while waiting in the executor queue 
+    private static class RequestWrapper implements Callable<StreamResponseMessage> {
+
+        Callable<StreamResponseMessage> task;
+        Long startTime = null;
+
+        public RequestWrapper(Callable<StreamResponseMessage> task) {
+            this.task = task;
+        }
+
+        @Override
+        public StreamResponseMessage call() throws Exception {
+            startTime = System.nanoTime();
+            return task.call();
+        }
+
     }
 
 }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/spi/AbstractStreamClientConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/spi/AbstractStreamClientConfiguration.java
@@ -17,6 +17,7 @@ package org.jupnp.transport.spi;
 import org.jupnp.model.ServerClientTokens;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Christian Bauer
@@ -26,6 +27,7 @@ public abstract class AbstractStreamClientConfiguration implements StreamClientC
     protected ExecutorService requestExecutorService;
     protected int timeoutSeconds = 10;
     protected int logWarningSeconds = 5;
+    protected int retryAfterSeconds = (int) TimeUnit.MINUTES.toSeconds(10);
 
     protected AbstractStreamClientConfiguration(ExecutorService requestExecutorService) {
         this.requestExecutorService = requestExecutorService;
@@ -70,6 +72,21 @@ public abstract class AbstractStreamClientConfiguration implements StreamClientC
 
     public void setLogWarningSeconds(int logWarningSeconds) {
         this.logWarningSeconds = logWarningSeconds;
+    }
+
+    public int getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+
+    /**
+     * @param retryAfterSeconds
+     *            should a positive integer or 0 (to disable the functionality).
+     */
+    public void setRetryAfterSeconds(int retryAfterSeconds) {
+        if (retryAfterSeconds < 0) {
+            throw new IllegalArgumentException("Retry After Seconds can not be null!");
+        }
+        this.retryAfterSeconds = retryAfterSeconds;
     }
 
     /**

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/spi/StreamClientConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/spi/StreamClientConfiguration.java
@@ -43,6 +43,11 @@ public interface StreamClientConfiguration {
     public int getLogWarningSeconds();
 
     /**
+     * @return A request will not be executed again if it has failed in the last X seconds ({@code 0} to disable)
+     */
+    public int getRetryAfterSeconds();
+
+    /**
      * Used for outgoing HTTP requests if no other value was already set on messages.
      *
      * @param majorVersion The UPnP UDA major version.


### PR DESCRIPTION
Failed or timed out request will not be attempted again in the next 10 minutes.
If a request waited a lot of time in the executor queue and timed out because of that it will be attempted again.